### PR TITLE
J2e test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 	</repositories>
 
 	<properties>
-		<pac4jVersion>1.7.0</pac4jVersion>
+		<pac4jVersion>1.7.1</pac4jVersion>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/leleuj/ClientsBuilder.java
+++ b/src/main/java/org/leleuj/ClientsBuilder.java
@@ -2,47 +2,64 @@ package org.leleuj;
 
 import org.pac4j.cas.client.CasClient;
 import org.pac4j.core.client.Clients;
+import org.pac4j.core.client.ClientsFactory;
 import org.pac4j.http.client.BasicAuthClient;
 import org.pac4j.http.client.FormClient;
 import org.pac4j.http.credentials.SimpleTestUsernamePasswordAuthenticator;
 import org.pac4j.http.profile.UsernameProfileCreator;
 import org.pac4j.oauth.client.FacebookClient;
+import org.pac4j.oauth.client.StravaClient;
 import org.pac4j.oauth.client.TwitterClient;
 import org.pac4j.oidc.client.OidcClient;
-import org.pac4j.saml.client.Saml2Client;
+import org.pac4j.saml.client.SAML2Client;
+import org.pac4j.saml.client.SAML2ClientConfiguration;
 
-public class ClientsBuilder {
+import java.io.File;
 
-	public static Clients build() {
-		final OidcClient oidcClient = new OidcClient();
-        oidcClient.setClientID("343992089165-sp0l1km383i8cbm2j5nn20kbk5dk8hor.apps.googleusercontent.com");
-        oidcClient.setSecret("uR3D8ej1kIRPbqAFaxIE3HWh");
-        oidcClient.setDiscoveryURI("https://accounts.google.com/.well-known/openid-configuration");
-        oidcClient.addCustomParam("prompt", "consent");
+public class ClientsBuilder implements ClientsFactory {
 
-        final Saml2Client saml2Client = new Saml2Client();
-        saml2Client.setKeystorePath("resource:samlKeystore.jks");
-        saml2Client.setKeystorePassword("pac4j-demo-passwd");
-        saml2Client.setPrivateKeyPassword("pac4j-demo-passwd");
-        saml2Client.setIdpMetadataPath("resource:testshib-providers.xml");
+        @Override
+        public Clients build(final Object env) {
+                final OidcClient oidcClient = new OidcClient();
+                oidcClient.setClientID("343992089165-sp0l1km383i8cbm2j5nn20kbk5dk8hor.apps.googleusercontent.com");
+                oidcClient.setSecret("uR3D8ej1kIRPbqAFaxIE3HWh");
+                oidcClient.setDiscoveryURI("https://accounts.google.com/.well-known/openid-configuration");
+                oidcClient.addCustomParam("prompt", "consent");
 
-        final FacebookClient facebookClient = new FacebookClient("145278422258960", "be21409ba8f39b5dae2a7de525484da8");
-        final TwitterClient twitterClient = new TwitterClient("CoxUiYwQOSFDReZYdjigBA",
-                "2kAzunH5Btc4gRSaMr7D7MkyoJ5u1VzbOOzE8rBofs");
-        // HTTP
-        final FormClient formClient = new FormClient("http://localhost:8080/theForm",
-                new SimpleTestUsernamePasswordAuthenticator(), new UsernameProfileCreator());
-        final BasicAuthClient basicAuthClient = new BasicAuthClient(new SimpleTestUsernamePasswordAuthenticator(),
-                new UsernameProfileCreator());
+                final SAML2ClientConfiguration cfg = new SAML2ClientConfiguration("resource:samlKeystore.jks",
+                        "pac4j-demo-passwd",
+                        "pac4j-demo-passwd",
+                        "resource:testshib-providers.xml");
+                cfg.setMaximumAuthenticationLifetime(3600);
+                cfg.setServiceProviderEntityId("urn:mace:saml:pac4j.org");
+                cfg.setServiceProviderMetadataPath(new File("target", "sp-metadata.xml").getAbsolutePath());
+                final SAML2Client saml2Client = new SAML2Client(cfg);
 
-        // CAS
-        final CasClient casClient = new CasClient();
-        // casClient.setGateway(true);
-        casClient.setCasLoginUrl("http://localhost:8888/cas/login");
-        casClient.setCasPrefixUrl("http://localhost:8888/cas/p3");
+                final FacebookClient facebookClient = new FacebookClient("145278422258960", "be21409ba8f39b5dae2a7de525484da8");
+                final TwitterClient twitterClient = new TwitterClient("CoxUiYwQOSFDReZYdjigBA",
+                        "2kAzunH5Btc4gRSaMr7D7MkyoJ5u1VzbOOzE8rBofs");
+                // HTTP
+                final FormClient formClient = new FormClient("http://localhost:8080/theForm.jsp",
+                        new SimpleTestUsernamePasswordAuthenticator(), new UsernameProfileCreator());
+                final BasicAuthClient basicAuthClient = new BasicAuthClient(new SimpleTestUsernamePasswordAuthenticator(),
+                        new UsernameProfileCreator());
 
-        final Clients clients = new Clients("http://localhost:8080/callback", oidcClient, saml2Client, facebookClient,
-                twitterClient, formClient, basicAuthClient, casClient);
-        return clients;
-	}
+                // CAS
+                final CasClient casClient = new CasClient();
+                // casClient.setGateway(true);
+                casClient.setCasLoginUrl("http://localhost:8888/cas/login");
+                casClient.setCasPrefixUrl("http://localhost:8888/cas/p3");
+
+                // Strava
+                final StravaClient stravaClient = new StravaClient();
+                stravaClient.setApprovalPrompt("auto");
+                // client_id
+                stravaClient.setKey("3945");
+                // client_secret
+                stravaClient.setSecret("f03df80582396cddfbe0b895a726bac27c8cf739");
+                stravaClient.setScope("view_private");
+
+                return new Clients("http://localhost:8080/callback", oidcClient, saml2Client, facebookClient,
+                        twitterClient, formClient, basicAuthClient, casClient, stravaClient);
+        }
 }

--- a/src/main/java/org/leleuj/SparkPac4jDemo.java
+++ b/src/main/java/org/leleuj/SparkPac4jDemo.java
@@ -17,7 +17,7 @@ import org.pac4j.oauth.client.FacebookClient;
 import org.pac4j.oauth.client.TwitterClient;
 
 import org.pac4j.oidc.client.OidcClient;
-import org.pac4j.saml.client.Saml2Client;
+import org.pac4j.saml.client.SAML2Client;
 import org.pac4j.sparkjava.CallbackRoute;
 import org.pac4j.sparkjava.RequiresAuthenticationFilter;
 import org.pac4j.sparkjava.SparkWebContext;
@@ -35,7 +35,7 @@ public class SparkPac4jDemo {
 
 	public static void main(String[] args) {
 		setPort(8080);
-		final Clients clients = ClientsBuilder.build();
+		final Clients clients = new ClientsBuilder().build(null);
 		get("/", (rq, rs) -> index(rq, rs, clients), templateEngine);
 		final Route callback = new CallbackRoute(clients);
 		get("/callback", callback);
@@ -73,7 +73,7 @@ public class SparkPac4jDemo {
 		map.put("formUrl", clients.findClient(FormClient.class).getRedirectionUrl(context));
 		map.put("baUrl", clients.findClient(BasicAuthClient.class).getRedirectionUrl(context));
 		map.put("casUrl", clients.findClient(CasClient.class).getRedirectionUrl(context));
-		map.put("samlUrl", clients.findClient(Saml2Client.class).getRedirectionUrl(context));
+		map.put("samlUrl", clients.findClient(SAML2Client.class).getRedirectionUrl(context));
 		map.put("oidcUrl", clients.findClient(OidcClient.class).getRedirectionUrl(context));
 		return new ModelAndView(map, "index.mustache");
 	}

--- a/src/main/java/org/leleuj/SparkPac4jDemo.java
+++ b/src/main/java/org/leleuj/SparkPac4jDemo.java
@@ -45,7 +45,7 @@ public class SparkPac4jDemo {
 		before("/form", new RequiresAuthenticationFilter(clients, "FormClient"));
 		before("/basicauth", new RequiresAuthenticationFilter(clients, "BasicAuthClient"));
 		before("/cas", new RequiresAuthenticationFilter(clients, "CasClient"));
-		before("/saml2", new RequiresAuthenticationFilter(clients, "Saml2Client"));
+		before("/saml2", new RequiresAuthenticationFilter(clients, "SAML2Client"));
 		before("/oidc", new RequiresAuthenticationFilter(clients, "OidcClient"));
 		get("/facebook", (rq, rs) -> protectedIndex(rq), templateEngine);
 		get("/twitter", (rq, rs) -> protectedIndex(rq), templateEngine);


### PR DESCRIPTION
Following our discussion in [Issue #4](https://github.com/pac4j/spark-pac4j/issues/4), in this commit I used the Client Factory Builder used in J2E integrated into Spark-pac4J demo. I had no issues with any other clients but on SAML it fails exactly with the same error I was reporting on google groups.

Using your suggestion of using the j2e-pac4j-demo client builder on spark-pac4j-demo I get an issue with converting WebContexts from Spark to j2e - RequiresAuthenticatedFilter @ line 46.

